### PR TITLE
fix: Remove trailing apostrophe from change template in release draft…

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -24,7 +24,7 @@ categories:
 
 change-template: |
   - $TITLE (#$NUMBER) by @$AUTHOR
-    $BODY'
+    $BODY
 no-changes-template: 'No significant changes'
 
 template: |


### PR DESCRIPTION
…er configuration
<!-- start messages -->
<details><summary>Commits</summary>
<p>
<a href=https://github.com/borislavr/module1/commit/a9cc6825e4573e579ac52c0de8f97a5dfb881e9e>borislavr:</a> fix: Remove trailing apostrophe from change template in release drafter configuration

</p>
</details>
<!-- end messages -->
